### PR TITLE
add GetQuery, update GetFileById and GetReader

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -199,7 +199,8 @@ func (file *File) UnPublish(comment string) ([]byte, error) {
 
 // GetReader gets file io.ReadCloser
 func (file *File) GetReader() (io.ReadCloser, error) {
-	endpoint := fmt.Sprintf("%s/$value", file.endpoint)
+	siteURL := file.client.AuthCnfg.GetSiteURL()
+	endpoint := fmt.Sprintf("%s/_api/web/%s/$value", siteURL, file.endpoint)
 
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {

--- a/api/search.go
+++ b/api/search.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/koltyakov/gosip"
 )
@@ -150,6 +151,21 @@ func NewSearch(client *gosip.SPClient, endpoint string, config *RequestConfig) *
 		config:    config,
 		modifiers: NewODataMods(),
 	}
+}
+
+func (search *Search) GetQuery(query *SearchQuery) (SearchResp, error) {
+	sortList := query.SortList[0].Property + ":" + strconv.Itoa(query.SortList[0].Direction)
+	endpoint := fmt.Sprintf("%s/query?querytext='%s'&sortlist='%s'&enabledsorting=true&rowlimit=%d",
+		search.endpoint, query.QueryText, sortList, query.RowLimit)
+
+	client := NewHTTPClient(search.client)
+
+	headers := map[string]string{
+		"Accept":       "application/json",
+		"Content-Type": "application/json;odata=verbose;charset=utf-8",
+	}
+
+	return client.Get(endpoint, patchConfigHeaders(search.config, headers))
 }
 
 // PostQuery gets search results based on a `query`

--- a/api/web.go
+++ b/api/web.go
@@ -352,7 +352,7 @@ func (web *Web) GetFileByPath(serverRelativeURL string) *File {
 func (web *Web) GetFileByID(uniqueID string) *File {
 	return NewFile(
 		web.client,
-		fmt.Sprintf("%s/GetFileByID('%s')", web.endpoint, uniqueID),
+		fmt.Sprintf("GetFileByID('%s')", uniqueID),
 		web.config,
 	)
 }


### PR DESCRIPTION
Microsoft Graph OAuth Flow uses delegated permissions whereas Gosip client lib is built around application permissions, which required some changes to the client lib to work. 